### PR TITLE
Fix core dump because of zypak-wrapper

### DIFF
--- a/com.nordpass.NordPass.yaml
+++ b/com.nordpass.NordPass.yaml
@@ -29,6 +29,11 @@ modules:
         path: xz_support.patch
       - type: patch
         path: gcc10.diff
+  - name: zypak
+    sources:
+      - type: git
+        url: https://github.com/refi64/zypak
+        tag: v2022.04
 
   - shared-modules/libsecret/libsecret.json
 


### PR DESCRIPTION
Fix was suggested and confirmed here:
* https://github.com/electron/forge/issues/2805

// Closes #103